### PR TITLE
docs(changelog): finalize Go 0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ package (`ts/`, npm `aontu`) and the Go module (`go/`,
 `github.com/rjrodger/aontu/go`) are versioned independently; entries note
 which implementation each change affects.
 
-## Unreleased — TypeScript 0.47.0, Go 0.1.4
+## Go 0.1.4 — 2026-06-22 · TypeScript 0.47.0 (unreleased)
+
+### Fixed — spreads & `type()` (TypeScript and Go)
+
+- **`key()` through spreads (TypeScript and Go)**: `key()` (and other
+  path-dependent functions) no longer leak the *source* key when a spread
+  is applied through a `$ref` (`&:$.ref`) or through nested maps — they
+  resolve to the destination key at each level. The TypeScript behaviour
+  was brought to full Go parity.
+- **`type()` spreads now apply (TypeScript and Go)**: a `type()` used as a
+  spread emits its constrained values at the destination rather than
+  marking the destination as a type, so `&:type({k:key(),x:number})`
+  behaves like the non-type spread `&:{k:key(),x:number}` (`key()`
+  resolves to the destination key, kinds constrain, fields are emitted).
+  This holds for both inline and `$ref` spreads and for nested types;
+  previously an inline `type()` spread dropped the child in TypeScript and
+  a `type()`+`key()` spread errored in Go. Type/hide marks on applied
+  spreads are cleared recursively.
+- Salvaged the `perf0` spread spec corpus into the shared
+  `test/spec/spread-*.tsv` suite, run by both implementations.
 
 ### Fixed — fragility audit
 


### PR DESCRIPTION
Prepares the **Go 0.1.4** release (the patch bump over the last published tag `go/v0.1.3`).

The version const `go/aontu.go` is already at `0.1.4` (it flows to `aontu --version`), so this PR is changelog-only:

- Dates the **Go 0.1.4** release (2026-06-22); TypeScript stays unreleased at 0.47.0.
- Documents the spread / `type()` / `key()` parity work shipping in 0.1.4 (merged via #12) that wasn't yet in the changelog:
  - `key()` no longer leaks the source key through `$ref` / nested spreads.
  - `type()` spreads now *apply* (emit constrained values at the destination) for inline and `$ref` spreads and nested types.
  - Salvaged the `perf0` spread spec corpus into the shared suite.

**Release gate (green):** `go test ./...`, `go vet ./...`, `gofmt -l` all clean.

### Publishing (after merge)
Tag manually rather than `make publish-go V=0.1.4` — that target re-sets the version const and commits it, which would be a no-op (the const is already `0.1.4`) and fail:

```sh
git tag go/v0.1.4
git push origin main go/v0.1.4
gh release create go/v0.1.4 --title "go/v0.1.4" --notes "Go module release v0.1.4"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DQVKs5R9f4GFJDL1L2VG5)_