### PR TITLE
test+docs: colon-chain nested @import fixed by multisource go/v0.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,13 +208,11 @@ be added to `test/spec/*.tsv`:
 - **Parse-level canon.** Only `unify(src).canon` is in parity. The raw
   `parse(src).canon` of nested `&`/`|` is parenthesised in TS but flat in
   Go; this is invisible to the shared spec (which is unify-level).
-- **Colon-chain nested `@"file"` import (Go).** A colon-chain key whose
-  value is a bare import — `struct: minor: @"file"` — loads correctly in
-  TS but resolves to `{}` in Go: the Go `@tabnas/jsonic` port flattens
-  the colon-chain, so the import is parsed as a top-level bare mark and
-  hoisted to the root instead of becoming the nested value. The braced
-  form `struct: { minor: @"file" }` works identically in both and is the
-  workaround. Root cause is upstream (the pinned `@tabnas/jsonic/go`
-  parser), not aontu's own Go source. Full analysis:
-  [`docs/design/nested-import-colon-chain.md`](docs/design/nested-import-colon-chain.md).
+
+> **Previously divergent, now fixed:** a colon-chain key whose value was a
+> bare import — `struct: minor: @"file"` — used to resolve to `{}` in Go
+> (it loaded correctly in TS). Fixed upstream in `@tabnas/multisource/go`
+> v0.3.1 (pinned in `go/go.mod`); covered by the shared-spec regression
+> `file.tsv:load-colon-chain`. Background:
+> [`docs/design/nested-import-colon-chain.md`](docs/design/nested-import-colon-chain.md).
 

--- a/docs/design/nested-import-colon-chain.md
+++ b/docs/design/nested-import-colon-chain.md
@@ -1,7 +1,9 @@
 # Design note: colon-chain nested `@"file"` import drops the import (Go port)
 
-Status: **open defect in the Go port** — root cause is upstream, in the
-`@tabnas/jsonic/go` parser, not in aontu's own Go source.
+Status: **resolved** — fixed upstream in `@tabnas/multisource/go` v0.3.1
+(pinned in `go/go.mod`). Covered by the shared-spec regression
+`file.tsv:load-colon-chain`. The analysis below is kept as a record of
+the defect and its root cause.
 
 This note records a parity defect found while validating `aql:model`
 (and `voxgig/model`) against a canonical TypeScript-based test model. A
@@ -15,15 +17,18 @@ to a single rule.
 In the **Go** implementation, a *colon-chain* (nested-path) key whose
 value is a bare `@"file"` import silently resolves to `{}` (the import is
 lost) instead of loading the file. The **TypeScript** (canonical)
-implementation handles the same source correctly. Braced nesting works
-in both, at any depth, and is the supported workaround until the upstream
-parser is fixed.
+implementation handles the same source correctly.
 
-| Form                                       | TypeScript | Go      |
-|--------------------------------------------|------------|---------|
-| `x: @"minor.aon"`                          | ✅ loads    | ✅ loads |
-| `struct: { minor: @"minor.aon" }` (braced) | ✅ loads    | ✅ loads |
-| `struct: minor: @"minor.aon"` (colon-chain)| ✅ loads    | ❌ `{}`  |
+This was **fixed upstream in `@tabnas/multisource/go` v0.3.1**; the table
+below shows the Go behaviour **before** that bump (TypeScript was always
+correct). Braced nesting worked in both at any depth throughout, and
+remains the recommended form.
+
+| Form                                       | TypeScript | Go (≤ v0.3.0) | Go (≥ v0.3.1) |
+|--------------------------------------------|------------|---------------|---------------|
+| `x: @"minor.aon"`                          | ✅ loads    | ✅ loads       | ✅ loads       |
+| `struct: { minor: @"minor.aon" }` (braced) | ✅ loads    | ✅ loads       | ✅ loads       |
+| `struct: minor: @"minor.aon"` (colon-chain)| ✅ loads    | ❌ `{}`        | ✅ loads       |
 
 ## Reproduction
 
@@ -120,28 +125,28 @@ post-parse repair inside aontu.
   not involved; the import is already mis-placed in the jsonic node tree
   before aontu's `asVal` conversion runs.
 
-## Where the fix belongs
+## Resolution
 
-The fix belongs **upstream in `@tabnas/jsonic/go`** (the colon-chain
-implicit-map construction), or, failing that, in the
-`@tabnas/multisource/go` `custom` grammar so the bare-`@` injection
-handles arbitrary depth and a colon-chain value opens the directive as a
-value rather than a top-level mark. aontu pins these parser versions
-exactly (`go/go.mod`), and the spread/optional rules depend on parser
-internals (see `AGENTS.md`), so any version bump must be made
-deliberately and validated against the full shared spec.
+The fix landed **upstream in `@tabnas/multisource/go` v0.3.1**, which
+makes the bare-`@` injection / colon-chain value handling work at
+arbitrary depth. aontu's `go/go.mod` pins that version, and the change was
+validated against the full shared spec plus the new regression row
+`test/spec/file.tsv:load-colon-chain` (`a:b:@"…/foo.aon"` →
+`{"a":{"b":{"f":11}}}`), which passes in both implementations.
 
-Until then, aontu's Go port carries this as a known divergence (see the
-"Known TS/Go divergences" section of `AGENTS.md`).
+aontu pins these parser versions exactly (`go/go.mod`), and the
+spread/optional rules depend on parser internals (see `AGENTS.md`), so any
+future parser bump must still be made deliberately and validated against
+the full shared spec.
 
-## Workaround
+## Workaround (pre-v0.3.1)
 
-Use **braced nesting** instead of a colon-chain for an imported value. It
-is equivalent, works in both implementations at any depth, and loads the
-file correctly:
+Before the upstream fix, the supported form was **braced nesting** instead
+of a colon-chain for an imported value. It is equivalent, works in both
+implementations at any depth, and remains a fine style:
 
 ```aontu
-# Instead of:   struct: minor: @"minor.aon"
+# Equivalent to:   struct: minor: @"minor.aon"
 struct: { minor: @"minor.aon" }
 ```
 

--- a/test/spec/file.tsv
+++ b/test/spec/file.tsv
@@ -2,6 +2,8 @@
 # Columns: name<TAB>mode<TAB>src<TAB>expect ; mode: canon|gen|err
 load-top	gen	@"__FIXTURES__/foo.aon"	{"f":11}
 load-nested	gen	a:@"__FIXTURES__/foo.aon"	{"a":{"f":11}}
+# Colon-chain (nested-path) key whose value is a bare @"file" import.
+load-colon-chain	gen	a:b:@"__FIXTURES__/foo.aon"	{"a":{"b":{"f":11}}}
 load-merge	gen	b:1 a:@"__FIXTURES__/foo.aon"	{"b":1,"a":{"f":11}}
 load-car	gen	car:@"__FIXTURES__/car.aon"	{"car":{"color":"silver","doors":4}}
 load-unify	gen	car:@"__FIXTURES__/car.aon" car:{doors:number,wheels:4}	{"car":{"color":"silver","doors":4,"wheels":4}}


### PR DESCRIPTION
Main's bump of @tabnas/multisource/go to v0.3.1 fixes the colon-chain nested @"file" import defect (struct: minor: @"file" now loads in Go instead of resolving to {}), matching the canonical TypeScript behaviour.

- Add shared-spec regression file.tsv:load-colon-chain (a:b:@"…/foo.aon" -> {"a":{"b":{"f":11}}}), passing in both implementations.
- Update the design note status to resolved (fixed in v0.3.1) with a before/after behaviour table and the regression reference.
- Replace the AGENTS.md "Known divergence" entry with a "now fixed" note.

Full suite: 487 TS pass, all Go pass.


Claude-Session: https://claude.ai/code/session_01CZ7Jic1ZzyDwo1yuPyPhAt